### PR TITLE
Add missing type declarations for tcp.proxy module

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+declare module '@anzerr/tcp.proxy' {
+    export class Proxy extends events {
+        constructor(host: string, to: string)
+        close(): Promise<void>
+        public RX: string
+        public TX: string
+    }
+}


### PR DESCRIPTION
Basic d.ts file. Package.json contains the type reference, but the file was missing. 